### PR TITLE
Create stack in AWS cloudformation to create resources to validate permissions boundary

### DIFF
--- a/.github/workflows/cfn-lint-validation.yaml
+++ b/.github/workflows/cfn-lint-validation.yaml
@@ -19,4 +19,4 @@ jobs:
 
     - name: Validate CloudFormation templates
       run: |
-        find practice-questions -type f \( -name "*.yaml" -o -name "*.yml" \) -exec cfn-lint {} +
+        find practice-questions -type f \( -name "*.yaml" -o -name "*.yml" \) -exec cfn-lint --ignore-checks W1011 {} +

--- a/.github/workflows/cfn-lint-validation.yaml
+++ b/.github/workflows/cfn-lint-validation.yaml
@@ -19,6 +19,4 @@ jobs:
 
     - name: Validate CloudFormation templates
       run: |
-        for file in $(find practice-questions -type f \( -name "*.yaml" -o -name "*.yml" \)); do
-          cfn-lint -i W1011 $file || exit 1
-        done
+        cfn-lint -t practice-questions/security/question-01/permissions-boundary.yaml -i W1011

--- a/.github/workflows/cfn-lint-validation.yaml
+++ b/.github/workflows/cfn-lint-validation.yaml
@@ -1,0 +1,22 @@
+name: Validate CloudFormation Templates
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install cfn-lint
+      run: |
+        pip install cfn-lint
+
+    - name: Validate CloudFormation templates
+      run: |
+        find practice-questions -type f \( -name "*.yaml" -o -name "*.yml" \) -exec cfn-lint {} +

--- a/.github/workflows/cfn-lint-validation.yaml
+++ b/.github/workflows/cfn-lint-validation.yaml
@@ -19,4 +19,6 @@ jobs:
 
     - name: Validate CloudFormation templates
       run: |
-        find practice-questions -type f \( -name "*.yaml" -o -name "*.yml" \) -exec cfn-lint --ignore-checks W1011 {} +
+        for file in $(find practice-questions -type f \( -name "*.yaml" -o -name "*.yml" \)); do
+          cfn-lint -i W1011 $file || exit 1
+        done

--- a/.github/workflows/deploy-question-01.yaml
+++ b/.github/workflows/deploy-question-01.yaml
@@ -1,0 +1,29 @@
+name: Deploy to AWS
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Run manage resources script
+      env:
+        USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
+      run: |
+        python manage_resources.py

--- a/.github/workflows/deploy-question-01.yaml
+++ b/.github/workflows/deploy-question-01.yaml
@@ -20,7 +20,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
+        aws-region: ${{ env.AWS_REGION }}
 
     - name: Run manage resources script
       env:

--- a/practice-questions/security/question-01/manage-stacks.py
+++ b/practice-questions/security/question-01/manage-stacks.py
@@ -1,0 +1,55 @@
+import boto3
+import os
+
+# Configurations
+STACK_NAME_PERMISSIONS_BOUNDARY = 'question01-permissions-boundary-stack'
+TEMPLATE_BODY_PERMISSIONS_BOUNDARY = open('permissions-boundary.yaml', 'r').read()
+REGION = 'us-east-1'
+USER_PASSWORD = os.getenv('USER_PASSWORD')  # get password from environment variable
+
+# Initialize clients
+cf_client = boto3.client('cloudformation', region_name=REGION)
+
+def create_stack(stack_name, template_body):
+    try:
+        cf_client.describe_stacks(StackName=stack_name)
+        print(f'Stack {stack_name} already exists. Updating stack...')
+        cf_client.update_stack(
+            StackName=stack_name,
+            TemplateBody=template_body,
+            Parameters=[
+                {
+                    'ParameterKey': 'UserPassword',
+                    'ParameterValue': USER_PASSWORD,
+                    'UsePreviousValue': False
+                }
+            ],
+            Capabilities=['CAPABILITY_NAMED_IAM']
+        )
+        waiter = cf_client.get_waiter('stack_update_complete')
+    except cf_client.exceptions.ClientError as e:
+        if 'does not exist' in str(e):
+            print(f'Criando stack {stack_name}...')
+            cf_client.create_stack(
+                StackName=stack_name,
+                TemplateBody=template_body,
+                Parameters=[
+                    {
+                        'ParameterKey': 'UserPassword',
+                        'ParameterValue': USER_PASSWORD
+                    }
+                ],
+                Capabilities=['CAPABILITY_NAMED_IAM']
+            )
+            waiter = cf_client.get_waiter('stack_create_complete')
+        else:
+            raise
+    waiter.wait(StackName=stack_name)
+    print(f'Stack {stack_name} created/updated successfully.')
+
+if __name__ == '__main__':
+    try:
+        create_stack(STACK_NAME_PERMISSIONS_BOUNDARY, TEMPLATE_BODY_PERMISSIONS_BOUNDARY)
+    except Exception as e:
+        print(f'Erro ao criar/atualizar a stack: {e}')
+        raise

--- a/practice-questions/security/question-01/permissions-boundary.yaml
+++ b/practice-questions/security/question-01/permissions-boundary.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template to create resources in aws
+
+# PERMISSIONS BOUNDARY
+
+Parameters:
+  UserPassword:
+    Description: "Password for the IAM user"
+    Type: String
+    NoEcho: true
+    
+Resources:
+  PermissionBoundary:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: TutorialPermissionBoundary
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - iam:Get*
+              - iam:List*
+            Resource: "*"
+
+  # Uncomment for part 2
+  FullAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: TutorialFullAccessPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: "*"
+            Resource: "*"
+
+  TutorialUser:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: "tutorial-user"
+      LoginProfile:
+        Password: !Ref UserPassword
+        PasswordResetRequired: false
+      PermissionsBoundary: !Ref PermissionBoundary
+      # Uncomment for part 2
+      ManagedPolicyArns: 
+        - !Ref FullAccessPolicy # Uncomment for part 2

--- a/practice-questions/security/question-01/permissions-boundary.yaml
+++ b/practice-questions/security/question-01/permissions-boundary.yaml
@@ -23,7 +23,6 @@ Resources:
               - iam:List*
             Resource: "*"
 
-  # Uncomment for part 2
   FullAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -35,14 +34,13 @@ Resources:
             Action: "*"
             Resource: "*"
 
-  TutorialUser:
+  UserWithPermissionsBoundary:
     Type: AWS::IAM::User
     Properties:
-      UserName: "tutorial-user"
+      UserName: "tutorial-user-with-permissions-boundary"
       LoginProfile:
         Password: !Ref UserPassword
         PasswordResetRequired: false
       PermissionsBoundary: !Ref PermissionBoundary
-      # Uncomment for part 2
       ManagedPolicyArns: 
         - !Ref FullAccessPolicy # Uncomment for part 2


### PR DESCRIPTION
This PR creates a stack in AWS CloudFormation to create all resources needed to validate the permissions boundary alternative in our use case question.

- Create a GitHub Actions workflow to trigger a Python script that verifies if a CloudFormation stack already exists and updates or creates the stack.
- The stack will create a user with a permissions boundary that allows only read-only access to IAM and a managed policy that allows full access. This way, we can demonstrate that the permissions boundary will limit the scope of the identity policy.